### PR TITLE
Escape passwords in XML correctly, fix typo, and add Money type

### DIFF
--- a/DynamicsCRM2011_Connector.class.php
+++ b/DynamicsCRM2011_Connector.class.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * DynamicsCRM2011_Connector.class.php
- * 
+ *
  * This file defines the DynamicsCRM2011_Connector class that can be used to access
  * the Microsoft Dynamics 2011 system through SOAP calls from PHP.
- * 
+ *
  * @author Nick Price
  * @version $Revision: 1.7 $
  * @package DynamicsCRM2011
@@ -38,59 +38,59 @@
  *
  */
 
- 
+
 /**
  * This class creates and manages SOAP connections to a Microsoft Dynamics CRM 2011 server
- * 
- * Authentication requirements are all handled automatically - although only 
- * Federation security is current supported, and an Exception is generated if 
+ *
+ * Authentication requirements are all handled automatically - although only
+ * Federation security is current supported, and an Exception is generated if
  * any other security method is detected on the server.
  *
- * The goal of this class is to make it as simple as possible to use SOAP data fetched 
+ * The goal of this class is to make it as simple as possible to use SOAP data fetched
  * directly from the Dynamics CRM server, without having to manually generate long stretches
  * of XML to be converted into SOAP calls.
- * 
- * Additionally, the returned data can be parsed in such a way that it can be used as 
+ *
+ * Additionally, the returned data can be parsed in such a way that it can be used as
  * simple PHP Objects, rather than complex XML to be parsed.
  */
 class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	/* Organization Details */
-	private $discoveryURI;
-	private $organizationUniqueName;
-	private $organizationURI;
+	protected $discoveryURI;
+	protected $organizationUniqueName;
+	protected $organizationURI;
 	/* Security Details */
-	private $security = Array();
-	private $callerId = NULL;
+	protected $security = Array();
+	protected $callerId = NULL;
 	/* Cached Discovery data */
-	private $discoveryDOM;
-	private $discoverySoapActions;
-	private $discoveryExecuteAction;
-	private $discoverySecurityPolicy;
+	protected $discoveryDOM;
+	protected $discoverySoapActions;
+	protected $discoveryExecuteAction;
+	protected $discoverySecurityPolicy;
 	/* Cached Organization data */
-	private $organizationDOM;
-	private $organizationSoapActions;
-	private $organizationCreateAction;
-	private $organizationDeleteAction;
-	private $organizationExecuteAction;
-	private $organizationRetrieveAction;
-	private $organizationRetrieveMultipleAction;
-	private $organizationUpdateAction;
-	private $organizationSecurityPolicy;
-	private $organizationSecurityToken;
+	protected $organizationDOM;
+	protected $organizationSoapActions;
+	protected $organizationCreateAction;
+	protected $organizationDeleteAction;
+	protected $organizationExecuteAction;
+	protected $organizationRetrieveAction;
+	protected $organizationRetrieveMultipleAction;
+	protected $organizationUpdateAction;
+	protected $organizationSecurityPolicy;
+	protected $organizationSecurityToken;
 	/* Cached Entity Definitions */
 	private $cachedEntityDefintions = Array();
 	/* Connection Details */
 	protected static $connectorTimeout = 600;
 	protected static $maximumRecords = self::MAX_CRM_RECORDS;
-	
+
 	/**
 	 * Create a new instance of the DynamicsCRM2011Connector
 	 *
 	 * This function is automatically called when a new instance is created.
 	 * At a minimum, you must provide the URL of the DiscoveryService (which can
-	 * be found on the Customizations / Developer Resources section of the Microsoft 
-	 * Dynamics CRM 2011 application), and the Unique Name of the Organization to connect 
-	 * to.  Note that it is often possible to connect to multiple Organizations from a 
+	 * be found on the Customizations / Developer Resources section of the Microsoft
+	 * Dynamics CRM 2011 application), and the Unique Name of the Organization to connect
+	 * to.  Note that it is often possible to connect to multiple Organizations from a
 	 * single Discovery Service, which is why this parameter is mandatory.
 	 *
 	 * Optionally, you may supply the username & password to login to the server immediately.
@@ -105,61 +105,61 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	function __construct($_discoveryURI, $_organizationUniqueName = NULL, $_username = NULL, $_password = NULL, $_debug = FALSE) {
 		/* Enable or disable debug mode */
 		self::$debugMode = $_debug;
-		
+
 		/* Check if we're using a cached login */
 		if (is_array($_discoveryURI)) {
 			return $this->loadLoginCache($_discoveryURI);
 		}
-		
+
 		/* Store the organization details */
 		$this->discoveryURI = $_discoveryURI;
 		$this->organizationUniqueName = $_organizationUniqueName;
-		
+
 		/* If either mandatory parameter is NULL, throw an Exception */
 		if ($this->discoveryURI == NULL || $this->organizationUniqueName == NULL) {
 			throw new BadMethodCallException(get_class($this).' constructor requires the Discovery URI and Organization Unique Name');
 		}
-		
+
 		/* Store the security details */
 		$this->security['username'] = $_username;
 		$this->security['password'] = $_password;
-		
+
 		/* Determine the Security used by this Organization */
 		$this->security['discovery_authmode'] = $this->getDiscoveryAuthenticationMode();
-		
+
 		/* Only Federation security is supported */
 		if ($this->security['discovery_authmode'] != 'Federation') {
 			throw new UnexpectedValueException(get_class($this).' does not support "'.$this->security['discovery_authmode'].'" authentication mode used by Discovery Service');
 		}
-		
+
 		/* Determine the address to send security requests to */
 		$this->security['discovery_authuri'] = $this->getDiscoveryAuthenticationAddress();
-		
+
 		/* Store the Security Service Endpoint for future use */
 		$this->security['discovery_authendpoint'] = $this->getFederationSecurityURI('discovery');
-		
+
 		/* If we already have all the Discovery Security details, determine the Organization URI */
 		if ($this->checkSecurity('discovery'))
 			$this->organizationURI = $this->getOrganizationURI();
 	}
-	
+
 	/**
 	 * Set the Federation Security Details for the Discovery Service
-	 * 
+	 *
 	 * If the constructor was called without the username and password, you must call
 	 * this function to login to the server.  Otherwise, all future calls to functions
 	 * to retrieve data will fail.
 	  *
 	 * Note that the current implementation assumes that only one login and password
 	 * is required for both the Discovery and Organization services.
-	 * 
+	 *
 	 * Once the login details are provided, the system will connect to the Discovery service
-	 * and find the URL for the Organization Service for the Organization specified in the 
+	 * and find the URL for the Organization Service for the Organization specified in the
 	 * constructor.
-	 * 
+	 *
 	 * @param string $_username the Username to login with
 	 * @param string $_password the Password of the user
-	 * @return boolean indication as to whether the login details were successfully used to fetch the 
+	 * @return boolean indication as to whether the login details were successfully used to fetch the
 	 * Organization service URL
 	 * @throws Exception if the username or password is missing, or if the system does not use Federation security
 	 */
@@ -180,7 +180,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		if ($this->organizationURI == NULL) return FALSE;
 		return TRUE;
 	}
-	
+
 	/**
 	 * Get the Discovery URL which is currently in use
 	 * @return string the URL of the Discovery Service
@@ -188,7 +188,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	public function getDiscoveryURI() {
 		return $this->discoveryURI;
 	}
-	
+
 	/**
 	 * Get the Organization Unique Name which is currently in use
 	 * @return string the Unique Name of the Organization
@@ -196,7 +196,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	public function getOrganization() {
 		return $this->organizationUniqueName;
 	}
-	
+
 	/**
 	 * Get the maximum records for a query
 	 * @return int the maximum records that will be returned from RetrieveMultiple per page
@@ -204,7 +204,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	public static function getMaximumRecords() {
 		return self::$maximumRecords;
 	}
-	
+
 	/**
 	 * Set the maximum records for a query
 	 * @param int $_maximumRecords the maximum number of records to fetch per page
@@ -213,7 +213,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		if (!is_int($_maximumRecords)) return;
 		self::$maximumRecords = $_maximumRecords;
 	}
-	
+
 	/**
 	 * Get the connector timeout value
 	 * @return int the maximum time the connector will wait for a response from the CRM in seconds
@@ -221,7 +221,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	public static function getConnectorTimeout() {
 		return self::$connectorTimeout;
 	}
-	
+
 	/**
 	 * Set the connector timeout value
 	 * @param int $_connectorTimeout maximum time the connector will wait for a response from the CRM in seconds
@@ -230,31 +230,31 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		if (!is_int($_connectorTimeout)) return;
 		self::$connectorTimeout = $_connectorTimeout;
 	}
-	
+
 	/**
 	 * Get the Discovery URL which is currently in use
 	 * @return string the URL of the Organization service
-	 * @throws Exception if the Discovery Service security details have not been set, 
+	 * @throws Exception if the Discovery Service security details have not been set,
 	 * or the Organization Service URL cannot be found for the current Organization
 	 */
 	public function getOrganizationURI() {
 		/* If it's set, return the details from the class instance */
 		if ($this->organizationURI != NULL) return $this->organizationURI;
-		
+
 		/* Check we have the appropriate security details for the Discovery Service */
 		if ($this->checkSecurity('discovery') == FALSE)
 			throw new Exception('Cannot determine Organization URI before Discovery Service Security Details are set!');
-		
+
 		/* Request a Security Token for the Discovery Service */
 		$securityToken = $this->requestSecurityToken($this->security['discovery_authendpoint'], $this->discoveryURI, $this->security['username'], $this->security['password']);
-		
+
 		/* Determine the Soap Action for the Execute method of the Discovery Service */
 		$discoveryServiceSoapAction = $this->getDiscoveryExecuteAction();
-		
+
 		/* Generate a Soap Request for the Retrieve Organization Request method of the Discovery Service */
 		$discoverySoapRequest = self::generateSoapRequest($this->discoveryURI, $discoveryServiceSoapAction, $securityToken, self::generateRetrieveOrganizationRequest());
 		$discovery_data = self::getSoapResponse($this->discoveryURI, $discoverySoapRequest);
-		
+
 		/* Parse the returned data to determine the correct EndPoint for the OrganizationService for the selected Organization */
 		$organizationServiceURI = NULL;
 		$discoveryDOM = new DOMDocument(); $discoveryDOM->loadXML($discovery_data);
@@ -282,7 +282,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$this->cacheOrganizationDetails();
 		return $organizationServiceURI;
 	}
-	
+
 	/**
 	 * Utility function to get the details of the Organization
 	 * Determines the Authenticaion mode, Authentication URL & Endpoint and SoapAction
@@ -291,25 +291,25 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	private function cacheOrganizationDetails() {
 		/* Check if this is already done... */
 		if ($this->organizationSoapActions != NULL) return;
-		
+
 		/* Determine the Security used by this Organization */
 		$this->security['organization_authmode'] = $this->getOrganizationAuthenticationMode();
-		
+
 		/* Only Federation security is supported */
 		if ($this->security['organization_authmode'] != 'Federation') {
 			throw new UnexpectedValueException(get_class($this).' does not support "'.$this->security['organization_authmode'].'" authentication mode used by Organization Service');
 		}
-		
+
 		/* Determine the address to send security requests to */
 		$this->security['organization_authuri'] = $this->getOrganizationAuthenticationAddress();
 		/* Store the Security Service Endpoint for future use */
 		$this->security['organization_authendpoint'] = $this->getFederationSecurityURI('organization');
-		
+
 		/* Determine the Soap Action for the Execute method of the Organization Service */
 		$organizationExecuteAction = $this->getOrganizationExecuteAction();
-		
+
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the Discovery Service
 	 * @ignore
@@ -320,10 +320,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllDiscoverySoapActions();
 			$this->discoveryExecuteAction = $actions['Execute'];
 		}
-		
+
 		return $this->discoveryExecuteAction;
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the Execute method of the Organization Service
 	 * @ignore
@@ -334,10 +334,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllOrganizationSoapActions();
 			$this->organizationExecuteAction = $actions['Execute'];
 		}
-		
+
 		return $this->organizationExecuteAction;
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the RetrieveMultiple method
 	 * @ignore
@@ -348,10 +348,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllOrganizationSoapActions();
 			$this->organizationRetrieveMultipleAction = $actions['RetrieveMultiple'];
 		}
-		
+
 		return $this->organizationRetrieveMultipleAction;
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the Retrieve method
 	 * @ignore
@@ -362,10 +362,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllOrganizationSoapActions();
 			$this->organizationRetrieveAction = $actions['Retrieve'];
 		}
-		
+
 		return $this->organizationRetrieveAction;
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the Create method
 	 * @ignore
@@ -376,10 +376,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllOrganizationSoapActions();
 			$this->organizationCreateAction = $actions['Create'];
 		}
-	
+
 		return $this->organizationCreateAction;
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the Delete method
 	 * @ignore
@@ -390,10 +390,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllOrganizationSoapActions();
 			$this->organizationDeleteAction = $actions['Delete'];
 		}
-	
+
 		return $this->organizationDeleteAction;
 	}
-	
+
 	/**
 	 * Utility function to get the SoapAction for the Update method
 	 * @ignore
@@ -404,10 +404,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			$actions = $this->getAllOrganizationSoapActions();
 			$this->organizationUpdateAction = $actions['Update'];
 		}
-	
+
 		return $this->organizationUpdateAction;
 	}
-	
+
 	/**
 	 * Utility function to validate the security details for the selected service
 	 * @return boolean indicator showing if the security details are okay
@@ -422,7 +422,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		}
 		return FALSE;
 	}
-	
+
 	/**
 	 * Utility function to validate Federation security details for the selected service
 	 * Checks the Authentication Mode is Federation, and verifies all the necessary data exists
@@ -438,7 +438,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		}
 		return TRUE;
 	}
-	
+
 	/**
 	 * Utility function to generate the XML for a Retrieve Organization request
 	 * This XML can be sent as a SOAP message to the Discovery Service to determine all Organizations
@@ -453,41 +453,41 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$requestNode->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'i:type', 'RetrieveOrganizationsRequest');
 		$requestNode->appendChild($retrieveOrganizationRequestDOM->createElement('AccessType', 'Default'));
 		$requestNode->appendChild($retrieveOrganizationRequestDOM->createElement('Release', 'Current'));
-		
+
 		return $executeNode;
 	}
-	
+
 	/**
-	 * Get the SOAP Endpoint for the Federation Security service 
+	 * Get the SOAP Endpoint for the Federation Security service
 	 * @ignore
 	 */
 	protected function getFederationSecurityURI($service) {
 		/* If it's set, return the details from the Security array */
-		if (isset($this->security[$service.'_authendpoint'])) 
+		if (isset($this->security[$service.'_authendpoint']))
 			return $this->security[$service.'_authendpoint'];
-		
+
 		/* Fetch the WSDL for the Authentication Service as a parseable DOM Document */
 		if (self::$debugMode) echo 'Getting WSDL data from: '.$this->security[$service.'_authuri'].PHP_EOL;
 		$authenticationDOM = new DOMDocument();
 		@$authenticationDOM->load($this->security[$service.'_authuri']);
 		/* Flatten the WSDL and include all the Imports */
 		$this->mergeWSDLImports($authenticationDOM);
-		
+
 		// Note: Find the real end-point to use for my security request - for now, we hard-code to Trust13 Username & Password using known values
 		// See http://code.google.com/p/php-dynamics-crm-2011/issues/detail?id=4
 		$authEndpoint = self::getTrust13UsernameAddress($authenticationDOM);
 		return $authEndpoint;
 	}
-	
+
 	/**
-	 * Return the Authentication Mode used by the Discovery service 
+	 * Return the Authentication Mode used by the Discovery service
 	 * @ignore
 	 */
 	protected function getDiscoveryAuthenticationMode() {
 		/* If it's set, return the details from the Security array */
-		if (isset($this->security['discovery_authmode'])) 
+		if (isset($this->security['discovery_authmode']))
 			return $this->security['discovery_authmode'];
-		
+
 		/* Get the Discovery DOM */
 		$discoveryDOM = $this->getDiscoveryDOM();
 		/* Get the Security Policy for the Organization Service from the WSDL */
@@ -496,16 +496,16 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$authType = $this->discoverySecurityPolicy->getElementsByTagName('Authentication')->item(0)->textContent;
 		return $authType;
 	}
-	
+
 	/**
-	 * Return the Authentication Mode used by the Organization service 
+	 * Return the Authentication Mode used by the Organization service
 	 * @ignore
 	 */
 	protected function getOrganizationAuthenticationMode() {
 		/* If it's set, return the details from the Security array */
-		if (isset($this->security['organization_authmode'])) 
+		if (isset($this->security['organization_authmode']))
 			return $this->security['organization_authmode'];
-		
+
 		/* Get the Organization DOM */
 		$organizationDOM = $this->getOrganizationDOM();
 		/* Get the Security Policy for the Organization Service from the WSDL */
@@ -514,16 +514,16 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$authType = $this->organizationSecurityPolicy->getElementsByTagName('Authentication')->item(0)->textContent;
 		return $authType;
 	}
-	
+
 	/**
-	 * Return the Authentication Address used by the Discovery service 
+	 * Return the Authentication Address used by the Discovery service
 	 * @ignore
 	 */
 	protected function getDiscoveryAuthenticationAddress() {
 		/* If it's set, return the details from the Security array */
-		if (isset($this->security['discovery_authuri'])) 
+		if (isset($this->security['discovery_authuri']))
 			return $this->security['discovery_authuri'];
-		
+
 		/* If we don't already have a Security Policy, get it */
 		if ($this->discoverySecurityPolicy == NULL) {
 			/* Get the Discovery DOM */
@@ -531,21 +531,21 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			/* Get the Security Policy for the Organization Service from the WSDL */
 			$this->discoverySecurityPolicy = self::findSecurityPolicy($discoveryDOM, 'DiscoveryService');
 		}
-		
+
 		/* Find the Authentication type used */
 		$authAddress = self::getFederatedSecurityAddress($this->discoverySecurityPolicy);
 		return $authAddress;
 	}
-	
+
 	/**
-	 * Return the Authentication Address used by the Organization service 
+	 * Return the Authentication Address used by the Organization service
 	 * @ignore
 	 */
 	protected function getOrganizationAuthenticationAddress() {
 		/* If it's set, return the details from the Security array */
-		if (isset($this->security['organization_authuri'])) 
+		if (isset($this->security['organization_authuri']))
 			return $this->security['organization_authuri'];
-		
+
 		/* If we don't already have a Security Policy, get it */
 		if ($this->organizationSecurityPolicy == NULL) {
 			/* Get the Organization DOM */
@@ -558,7 +558,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$authAddress = self::getFederatedSecurityAddress($this->organizationSecurityPolicy);
 		return $authAddress;
 	}
-	
+
 	/**
 	 * Fetch and flatten the Discovery Service WSDL as a DOM
 	 * @ignore
@@ -566,19 +566,19 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	protected function getDiscoveryDOM() {
 		/* If it's already been fetched, use the one we have */
 		if ($this->discoveryDOM != NULL) return $this->discoveryDOM;
-		
+
 		/* Fetch the WSDL for the Discovery Service as a parseable DOM Document */
 		if (self::$debugMode) echo 'Getting WSDL data from: '.$this->discoveryURI.'?wsdl'.PHP_EOL;
 		$discoveryDOM = new DOMDocument();
 		@$discoveryDOM->load($this->discoveryURI.'?wsdl');
 		/* Flatten the WSDL and include all the Imports */
 		$this->mergeWSDLImports($discoveryDOM);
-		
+
 		/* Cache the DOM in the current object */
 		$this->discoveryDOM = $discoveryDOM;
 		return $discoveryDOM;
 	}
-	
+
 	/**
 	 * Fetch and flatten the Organization Service WSDL as a DOM
 	 * @ignore
@@ -589,31 +589,31 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		if ($this->organizationURI == NULL) {
 			throw new Exception('Cannot get Organization DOM before determining Organization URI');
 		}
-		
-		
+
+
 		/* Fetch the WSDL for the Organization Service as a parseable DOM Document */
 		if (self::$debugMode) echo 'Getting WSDL data from: '.$this->organizationURI.'?wsdl'.PHP_EOL;
-		$organizationDOM = new DOMDocument(); 
+		$organizationDOM = new DOMDocument();
 		@$organizationDOM->load($this->organizationURI.'?wsdl');
 		/* Flatten the WSDL and include all the Imports */
 		$this->mergeWSDLImports($organizationDOM);
-		
+
 		/* Cache the DOM in the current object */
 		$this->organizationDOM = $organizationDOM;
 		return $organizationDOM;
 	}
-	
+
 	/**
-	 * Get the Trust Address for the Trust13UsernameMixed authentication method 
+	 * Get the Trust Address for the Trust13UsernameMixed authentication method
 	 * @ignore
 	 */
 	protected static function getTrust13UsernameAddress(DOMDocument $authenticationDOM) {
 		return self::getTrustAddress($authenticationDOM, 'UserNameWSTrustBinding_IWSTrust13Async');
 	}
-	
+
 	/**
-	 * Search the WSDL from an ADFS server to find the correct end-point for a 
-	 * call to RequestSecurityToken with a given set of parmameters 
+	 * Search the WSDL from an ADFS server to find the correct end-point for a
+	 * call to RequestSecurityToken with a given set of parmameters
 	 * @ignore
 	 */
 	protected static function getTrustAddress(DOMDocument $authenticationDOM, $trustName) {
@@ -641,10 +641,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the found URI */
 		return $authenticationURI;
 	}
-	
+
 	/**
-	 * Search a WSDL XML DOM for "import" tags and import the files into 
-	 * one large DOM for the entire WSDL structure 
+	 * Search a WSDL XML DOM for "import" tags and import the files into
+	 * one large DOM for the entire WSDL structure
 	 * @ignore
 	 */
 	protected function mergeWSDLImports(DOMNode &$wsdlDOM, $continued = false, DOMDocument &$newRootDocument = NULL) {
@@ -714,7 +714,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		}
 		return $wsdlDOM;
 	}
-	
+
 	/**
 	 * Search a Microsoft Dynamics CRM 2011 WSDL for the Security Policy for a given Service
 	 * @ignore
@@ -783,7 +783,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the selected node */
 		return $securityPolicyNode;
 	}
-	
+
 	/**
 	 * Search a Microsoft Dynamics CRM 2011 WSDL for all available Operations/SoapActions on a Service
 	 * @ignore
@@ -843,13 +843,13 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				unset($soap12OperationNode);
 			}
 		}
-		
+
 		/* Return the array of available actions */
 		return $operationArray;
 	}
-	
-	/** 
-	 * Get all the Operations & corresponding SoapActions for the DiscoveryService 
+
+	/**
+	 * Get all the Operations & corresponding SoapActions for the DiscoveryService
 	 */
 	public function getAllDiscoverySoapActions() {
 		/* If it is not cached, update the cache */
@@ -859,8 +859,8 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the cached value */
 		return $this->discoverySoapActions;
 	}
-	
-	/** 
+
+	/**
 	 * Get all the Operations & corresponding SoapActions for the OrganizationService
 	 */
 	public function getAllOrganizationSoapActions() {
@@ -871,7 +871,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the cached value */
 		return $this->organizationSoapActions;
 	}
-	
+
 	/**
 	 * Search a Microsoft Dynamics CRM 2011 WSDL for the SoapAction for a given Operation on a Service
 	 * @ignore
@@ -940,9 +940,9 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the selected node */
 		return $soapAction;
 	}
-	
+
 	/**
-	 * Search a Microsoft Dynamics CRM 2011 Security Policy for the Address for the Federated Security 
+	 * Search a Microsoft Dynamics CRM 2011 Security Policy for the Address for the Federated Security
 	 * @ignore
 	 */
 	protected static function getFederatedSecurityAddress(DOMNode $securityPolicyNode) {
@@ -991,9 +991,9 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		}
 		return $securityURL;
 	}
-	
+
 	/**
-	 * Request a Security Token from the ADFS server using Username & Password authentication 
+	 * Request a Security Token from the ADFS server using Username & Password authentication
 	 * @ignore
 	 */
 	protected function requestSecurityToken($securityServerURI, $loginEndpoint, $loginUsername, $loginPassword) {
@@ -1020,7 +1020,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$expiryTime = $securityDOM->getElementsByTagName("RequestSecurityTokenResponse")->item(0)->getElementsByTagName('Expires')->item(0)->textContent;
 		/* Convert it to a PHP Timestamp */
 		$expiryTime = self::parseTime(substr($expiryTime, 0, -5), '%Y-%m-%dT%H:%M:%S');
-		
+
 		/* Return an associative Array */
 		$securityToken = Array(
 				'securityToken' => $requestedSecurityToken,
@@ -1041,9 +1041,9 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return an associative Array */
 		return $securityToken;
 	}
-	
+
 	/**
-	 * Get the XML needed to send a login request to the Username & Password Trust service 
+	 * Get the XML needed to send a login request to the Username & Password Trust service
 	 * @ignore
 	 */
 	protected static function getLoginXML($securityServerURI, $loginEndpoint, $loginUsername, $loginPassword) {
@@ -1067,25 +1067,25 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$pass_str = $loginSoapRequest->saveXML($pass);
 		$loginUsernameToken->appendChild($loginSoapRequest->createElement('o:Username', $loginUsername));
 		$loginUsernameToken->appendChild($loginSoapRequest->createElement('o:Password', $pass_str))->setAttribute('Type', 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText');
-		
+
 		$loginBody = $loginEnvelope->appendChild($loginSoapRequest->createElementNS('http://www.w3.org/2003/05/soap-envelope', 's:Body'));
 		$loginRST = $loginBody->appendChild($loginSoapRequest->createElementNS('http://docs.oasis-open.org/ws-sx/ws-trust/200512', 'trust:RequestSecurityToken'));
 		$loginAppliesTo = $loginRST->appendChild($loginSoapRequest->createElementNS('http://schemas.xmlsoap.org/ws/2004/09/policy', 'wsp:AppliesTo'));
 		$loginEndpointReference = $loginAppliesTo->appendChild($loginSoapRequest->createElement('a:EndpointReference'));
 		$loginEndpointReference->appendChild($loginSoapRequest->createElement('a:Address', $loginEndpoint));
 		$loginRST->appendChild($loginSoapRequest->createElement('trust:RequestType', 'http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue'));
-		
+
 		return $loginSoapRequest->saveXML($loginEnvelope);
 	}
-	
+
 	/**
-	 * Send the SOAP message, and get the response 
+	 * Send the SOAP message, and get the response
 	 * @ignore
 	 */
 	protected static function getSoapResponse($soapUrl, $content) {
 		/* Separate the provided URI into Path & Hostname sections */
 		$urlDetails = parse_url($soapUrl);
-		
+
 		// setup headers
 		$headers = array(
 				"POST ". $urlDetails['path'] ." HTTP/1.1",
@@ -1094,7 +1094,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				"Content-type: application/soap+xml; charset=UTF-8",
 				"Content-length: ".strlen($content),
 		);
-		
+
 		$cURLHandle = curl_init();
 		curl_setopt($cURLHandle, CURLOPT_URL, $soapUrl);
 		curl_setopt($cURLHandle, CURLOPT_RETURNTRANSFER, 1);
@@ -1114,9 +1114,9 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Check for HTTP errors */
 		$httpResponse = curl_getinfo($cURLHandle, CURLINFO_HTTP_CODE);
 		curl_close($cURLHandle);
-		
+
 		if (self::$debugMode) echo PHP_EOL.PHP_EOL.'SOAP Response:= '.PHP_EOL.$responseXML.PHP_EOL.PHP_EOL;
-		
+
 		/* Determine the Action in the SOAP Response */
 		$responseDOM = new DOMDocument();
 		$responseDOM->loadXML($responseXML);
@@ -1134,7 +1134,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				->getElementsByTagNameNS('http://www.w3.org/2003/05/soap-envelope', 'Header')->item(0)
 				->getElementsByTagNameNS('http://www.w3.org/2005/08/addressing', 'Action')->item(0)->textContent;
 		if (self::$debugMode) echo __FUNCTION__.': SOAP Action in returned XML is "'.$actionString.'"'.PHP_EOL;
-		
+
 		/* Handle known Error Actions */
 		if (in_array($actionString, self::$SOAPFaultActions)) {
 			// Get the Fault Code
@@ -1153,12 +1153,12 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				->getElementsByTagNameNS('http://www.w3.org/2003/05/soap-envelope', 'Text')->item(0)->nodeValue.PHP_EOL;
 			throw new SoapFault($faultCode, $faultString);
 		}
-		
+
 		return $responseXML;
 	}
-	
+
 	/**
-	 * Create the XML String for a Soap Request 
+	 * Create the XML String for a Soap Request
 	 * @ignore
 	 */
 	protected static function generateSoapRequest($serviceURI, $soapAction, $securityToken, DOMNode $bodyContentNode, $_callerId = NULL) {
@@ -1172,10 +1172,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Create the SOAP Body */
 		$soapBodyNode = $soapEnvelope->appendChild($soapRequestDOM->createElement('s:Body'));
 		$soapBodyNode->appendChild($soapRequestDOM->importNode($bodyContentNode, true));
-		
+
 		return $soapRequestDOM->saveXML($soapEnvelope);
 	}
-	
+
 	/**
 	 * Generate a Soap Header using the specified service URI and SoapAction
 	 * Include the details from the Security Token for login
@@ -1193,12 +1193,12 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$headerNode->appendChild($soapHeaderDOM->createElement('a:To', $serviceURI))->setAttribute('s:mustUnderstand', '1');
 		$securityHeaderNode = self::getSecurityHeaderNode($securityToken);
 		$headerNode->appendChild($soapHeaderDOM->importNode($securityHeaderNode, true));
-		
+
 		return $headerNode;
 	}
-	
+
 	/**
-	 * Generate a DOMNode for the o:Security header required for SOAP requests 
+	 * Generate a DOMNode for the o:Security header required for SOAP requests
 	 * @ignore
 	 */
 	protected static function getSecurityHeaderNode(Array $securityToken) {
@@ -1229,11 +1229,11 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$securityTokenReferenceNode = $keyInfoNode->appendChild($securityDOM->createElement('o:SecurityTokenReference'));
 		$securityTokenReferenceNode->setAttributeNS('http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd', 'k:TokenType', 'http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1');
 		$securityTokenReferenceNode->appendChild($securityDOM->createElement('o:KeyIdentifier', $securityToken['keyIdentifier']))->setAttribute('ValueType', 'http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.0#SAMLAssertionID');
-		
+
 		return $securityHeader;
 	}
-	
-	/** 
+
+	/**
 	 * Generate a Retrieve Multiple Request
 	 * @ignore
 	 */
@@ -1279,10 +1279,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $retrieveMultipleNode;
 	}
-	
+
 	/**
 	 * Find the PageNumber in a PagingCookie
-	 * 
+	 *
 	 * @param String $pagingCookie
 	 * @ignore
 	 */
@@ -1293,8 +1293,8 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$pageNo = $pagingDOM->documentElement->getAttribute('page');
 		return (int)$pageNo;
 	}
-	
-	/** 
+
+	/**
 	 * Generate a Retrieve Request
 	 * @ignore
 	 */
@@ -1322,8 +1322,8 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $retrieveNode;
 	}
-	
-	/** 
+
+	/**
 	 * Generate a Retrieve Record Change History Request
 	 * @ignore
 	 */
@@ -1349,8 +1349,8 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $executeNode;
 	}
-	
-	/** 
+
+	/**
 	 * Generate a Retrieve Entity Request
 	 * @ignore
 	 */
@@ -1359,10 +1359,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Use ID by preference, if not set, default to 0s */
 		if ($entityId != NULL) $entityType = NULL;
 		else $entityId = self::EmptyGUID;
-		
+
 		/* If no entityFilters are supplied, assume "All" */
 		if ($entityFilters == NULL) $entityFilters = 'Entity Attributes Privileges Relationships';
-		
+
 		/* Generate the RetrieveEntityRequest message */
 		$retrieveEntityRequestDOM = new DOMDocument();
 		$executeNode = $retrieveEntityRequestDOM->appendChild($retrieveEntityRequestDOM->createElementNS('http://schemas.microsoft.com/xrm/2011/Contracts/Services', 'Execute'));
@@ -1401,16 +1401,16 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $executeNode;
 	}
-	
+
 	/**
 	 * Add a list of Attributes to an Array of Attributes, using appropriate handling
 	 * of the Attribute type, and avoiding over-writing existing attributes
-	 * already in the array 
-	 * 
+	 * already in the array
+	 *
 	 * Optionally specify an Array of sub-keys, and a particular sub-key
 	 * - If provided, each sub-key in the Array will be created as an Object attribute,
 	 *   and the value will be set on the specified sub-key only (e.g. (New, Old) / New)
-	 * 
+	 *
 	 * @ignore
 	 */
 	protected static function addAttributes(Array &$targetArray, DOMNodeList $keyValueNodes, Array $keys = NULL, $key1 = NULL) {
@@ -1464,7 +1464,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			if ($keys == NULL) {
 				/* Assume that if there is a duplicate, it's a formatted version of this */
 				if (array_key_exists($attributeKey, $targetArray)) {
-					$responseDataArray[$attributeKey] = (Object)Array('Value' => $attributeValue, 
+					$responseDataArray[$attributeKey] = (Object)Array('Value' => $attributeValue,
 							'FormattedValue' => $targetArray[$attributeKey]);
 				} else {
 					$targetArray[$attributeKey] = $attributeValue;
@@ -1494,7 +1494,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			}
 		}
 	}
-	
+
 	/**
 	 * Parse the results of a RetrieveMultipleRequest into a useable PHP object
 	 * @param DynamicsCRM2011_Connector $conn
@@ -1559,12 +1559,12 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		}
 		/* Record the number of Entities */
 		$responseDataArray['Count'] = count($responseDataArray['Entities']);
-		
+
 		/* Convert the Array to a stdClass Object */
 		$responseData = (Object)$responseDataArray;
 		return $responseData;
 	}
-	
+
 	/**
 	 * Parse the results of a RetrieveRequest into a useable PHP object
 	 * @param DynamicsCRM2011_Connector $conn
@@ -1598,12 +1598,12 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Could not find RetrieveResult node in XML provided');
 			return FALSE;
 		}
-		
+
 		/* Generate a new Entity from the DOMNode */
 		$entity = DynamicsCRM2011_Entity::fromDOM($conn, $entityLogicalName, $retrieveResultNode);
 		return $entity;
 	}
-	
+
 	/**
 	 * Parse the results of a RetrieveRecordChangeHistory into a useable PHP object
 	 * @ignore
@@ -1647,7 +1647,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		foreach ($auditDetailCollectionNode->getElementsByTagName('AuditDetails')->item(0)->getElementsByTagName('AuditDetail') as $auditDetailNode) {
 			/* Create an Array to hold the AuditDetail properties */
 			$auditDetailArray = Array();
-			
+
 			/* Create an Array to hold the AuditRecord properties */
 			$auditRecordArray = Array();
 			/* Get the Attributes */
@@ -1660,13 +1660,13 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			self::addFormattedValues($auditRecordArray, $keyValueNodes);
 			/* Convert the Audit Details to an Object */
 			$auditDetailArray['AuditRecord'] = (Object)$auditRecordArray;
-			
+
 			//$auditDetailArray['InvalidNewValueAttributes'] = $auditDetailNode->getElementsByTagName('InvalidNewValueAttributes')->item(0)->C14N();
-			
+
 			/* Create an Array to hold the New & Old Value properties */
 			$valueArray = Array();
 			/* Get the New Attributes */
-			if ($auditDetailNode->getElementsByTagName('NewValue')->length > 0 && 
+			if ($auditDetailNode->getElementsByTagName('NewValue')->length > 0 &&
 					$auditDetailNode->getElementsByTagName('NewValue')->item(0)->getElementsByTagName('Attributes')->length > 0) {
 				/* Get the Attributes */
 				$keyValueNodes = $auditDetailNode->getElementsByTagName('NewValue')->item(0)
@@ -1682,7 +1682,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				self::addFormattedValues($valueArray, $keyValueNodes, Array('NewValue', 'OldValue'), 'NewValue');
 			}
 			/* Get the Old Attributes */
-			if ($auditDetailNode->getElementsByTagName('OldValue')->length > 0 && 
+			if ($auditDetailNode->getElementsByTagName('OldValue')->length > 0 &&
 					$auditDetailNode->getElementsByTagName('OldValue')->item(0)->getElementsByTagName('Attributes')->length > 0) {
 				/* Get the Attributes */
 				$keyValueNodes = $auditDetailNode->getElementsByTagName('OldValue')->item(0)
@@ -1701,17 +1701,17 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			/* Add the AuditDetail to the AuditDetails Array as a stdClass Object */
 			$responseDataArray['AuditDetails'][] = (Object)$auditDetailArray;
 		}
-		
+
 		/* Convert the Array to a stdClass Object */
 		$responseData = (Object)$responseDataArray;
-		
+
 		/* Sort the AuditDetails by CreatedOn in Ascending order */
 		$sortFunction = create_function('$a,$b', 'return ($a->AuditRecord->createdon->Value - $b->AuditRecord->createdon->Value);');
 		usort($responseData->AuditDetails, $sortFunction);
-		
+
 		return $responseData;
 	}
-	
+
 	/**
 	 * Parse the results of a RetrieveEntity into a useable PHP object
 	 * @ignore
@@ -1748,13 +1748,13 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		}
 		/* Assemble a simpleXML class for the details to return */
 		$responseData = simplexml_import_dom($entityMetadataNode);
-		
+
 		/* Return the SimpleXML object */
 		return $responseData;
 	}
-	
+
 	/**
-	 * Get the current Organization Service security token, or get a new one if necessary 
+	 * Get the current Organization Service security token, or get a new one if necessary
 	 * @ignore
 	 */
 	private function getOrganizationSecurityToken() {
@@ -1771,13 +1771,13 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Save the token, and return it */
 		return $this->organizationSecurityToken;
 	}
-	
+
 	/**
 	 * Send a RetrieveMultiple request to the Dynamics CRM 2011 server
 	 * and return the results as raw XML
 	 *
 	 * This is particularly useful when debugging the responses from the server
-	 * 
+	 *
 	 * @param string $queryXML the Fetch XML string (as generated by the Advanced Find tool on Microsoft Dynamics CRM 2011)
 	 * @param string $pagingCookie if multiple pages are returned, send the paging cookie to get pages 2 and onwards.  Use NULL to get the first page
 	 * @param integer $limitCount maximum number of records to be returned per page
@@ -1791,10 +1791,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Turn this into a SOAP request, and send it */
 		$retrieveMultipleSoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationRetrieveMultipleAction(), $securityToken, $executeNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveMultipleSoapRequest);
-		
+
 		return $soapResponse;
 	}
-	
+
 	/**
 	 * Send a RetrieveMultiple request to the Dynamics CRM 2011 server
 	 * and return the results as a structured Object
@@ -1824,7 +1824,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			}
 			/* Save the new Soap Data */
 			$soapData = $tmpSoapData;
-			
+
 			/* Check if the PagingCookie is present & needed */
 			if ($soapData->MoreRecords && $soapData->PagingCookie == NULL) {
 				/* Paging Cookie is not present in returned data, but is expected! */
@@ -1843,19 +1843,19 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				/* PagingCookie exists, or is not needed */
 				$pagingCookie = $soapData->PagingCookie;
 			}
-			
+
 			/* Loop while there are more records, and we want all pages */
 		} while ($soapData->MoreRecords && $allPages);
-		
+
 		/* Return the compiled structure */
 		return $soapData;
 	}
-	
+
 	/**
 	 * Send a RetrieveMultiple request to the Dynamics CRM 2011 server
 	 * and return the results as a structured Object
 	 * Each Entity returned is processed into a simple stdClass
-	 * 
+	 *
 	 * Note that this function is faster than using Entities, but not as strong
 	 * at handling complicated return types.
 	 *
@@ -1868,13 +1868,13 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	public function retrieveMultipleSimple($queryXML, $allPages = TRUE, $pagingCookie = NULL, $limitCount = NULL) {
 		return $this->retrieveMultiple($queryXML, $allPages, $pagingCookie, $limitCount, true);
 	}
-	
+
 	/**
 	 * Send a RetrieveRecordChangeHistory request to the Dynamics CRM 2011 server
 	 * and return the results as raw XML
 	 *
 	 * This is particularly useful when debugging the responses from the server
-	 * 
+	 *
 	 * @param string $entityType the LogicalName of the Entity to be retrieved (Incident, Account etc.)
 	 * @param string $entityId the internal Id of the Entity to be retrieved (without enclosing brackets)
 	 * @param string $pagingCookie if multiple pages are returned, send the paging cookie to get pages 2 and onwards.  Use NULL to get the first page
@@ -1888,10 +1888,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Turn this into a SOAP request, and send it */
 		$retrieveRecordChangeHistorySoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveRecordChangeHistorySoapRequest);
-		
+
 		return $soapResponse;
 	}
-	
+
 	/**
 	 * Send a RetrieveRecordChangeHistory request to the Dynamics CRM 2011 server
 	 * and return the results as a structured Object
@@ -1922,18 +1922,18 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			/* Grab the Paging Cookie */
 			$pagingCookie = $soapData->PagingCookie;
 		} while ($soapData->MoreRecords && $allPages);
-		
+
 		return $soapData;
 	}
-	
+
 	/**
 	 * Send a Retrieve request to the Dynamics CRM 2011 server and return the results as raw XML
 	 * This function is typically used just after creating something (where you get the ID back
-	 * as the return value), as it is more efficient to use RetrieveMultiple to search directly if 
+	 * as the return value), as it is more efficient to use RetrieveMultiple to search directly if
 	 * you don't already have the ID.
 	 *
 	 * This is particularly useful when debugging the responses from the server
-	 * 
+	 *
 	 * @param DynamicsCRM2011_Entity $entity the Entity to retrieve - must have an ID specified
 	 * @param array $fieldSet array listing all fields to be fetched, or null to get all fields
 	 * @return string the raw XML returned by the server, including all SOAP Envelope, Header and Body data.
@@ -1949,14 +1949,14 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Turn this into a SOAP request, and send it */
 		$retrieveRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationRetrieveAction(), $securityToken, $executeNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveRequest);
-		
+
 		return $soapResponse;
 	}
-	
+
 	/**
 	 * Send a Retrieve request to the Dynamics CRM 2011 server and return the results as a structured Object
 	 * This function is typically used just after creating something (where you get the ID back
-	 * as the return value), as it is more efficient to use RetrieveMultiple to search directly if 
+	 * as the return value), as it is more efficient to use RetrieveMultiple to search directly if
 	 * you don't already have the ID.
 	 *
 	 * @param DynamicsCRM2011_Entity $entity the Entity to retrieve - must have an ID specified
@@ -1969,7 +1969,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Cannot Retrieve an Entity without an ID.');
 			return FALSE;
 		}
-		
+
 		/* Get the raw XML data */
 		$rawSoapResponse = $this->retrieveRaw($entity, $fieldSet);
 		/* Parse the raw XML data into an Object */
@@ -1977,12 +1977,12 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the structured object */
 		return $newEntity;
 	}
-	
+
 	/**
 	 * Send a RetrieveEntity request to the Dynamics CRM 2011 server and return the results as raw XML
 	 *
 	 * This is particularly useful when debugging the responses from the server
-	 * 
+	 *
 	 * @param string $entityType the LogicalName of the Entity to be retrieved (Incident, Account etc.)
 	 * @return string the raw XML returned by the server, including all SOAP Envelope, Header and Body data.
 	 */
@@ -1994,10 +1994,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Turn this into a SOAP request, and send it */
 		$retrieveEntityRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveEntityRequest);
-		
+
 		return $soapResponse;
 	}
-	
+
 	/**
 	 * Send a RetrieveEntity request to the Dynamics CRM 2011 server and return the results as a structured Object
 	 *
@@ -2014,10 +2014,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the structured object */
 		return $soapData;
 	}
-	
+
 	/**
 	 * Send a Create request to the Dynamics CRM 2011 server, and return the ID of the newly created Entity
-	 * 
+	 *
 	 * @param DynamicsCRM2011_Entity $entity the Entity to create
 	 */
 	public function create(DynamicsCRM2011_Entity &$entity) {
@@ -2026,24 +2026,24 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Cannot Create an Entity that already exists.');
 			return FALSE;
 		}
-		
+
 		/* Send the sequrity request and get a security token */
 		$securityToken = $this->getOrganizationSecurityToken();
 		/* Generate the XML for the Body of a Create request */
 		$createNode = self::generateCreateRequest($entity);
-		
+
 		if (self::$debugMode) echo PHP_EOL.'Create Request: '.PHP_EOL.$createNode->C14N().PHP_EOL.PHP_EOL;
-		
+
 		/* Turn this into a SOAP request, and send it */
 		$createRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationCreateAction(), $securityToken, $createNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $createRequest);
-		
+
 		if (self::$debugMode) echo PHP_EOL.'Create Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
-		
+
 		/* Load the XML into a DOMDocument */
 		$soapResponseDOM = new DOMDocument();
 		$soapResponseDOM->loadXML($soapResponse);
-		
+
 		/* Find the CreateResponse */
 		$createResponseNode = NULL;
 		foreach ($soapResponseDOM->getElementsByTagName('CreateResponse') as $node) {
@@ -2055,14 +2055,14 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Could not find CreateResponse node in XML returned from Server');
 			return FALSE;
 		}
-		
+
 		/* Get the EntityID from the CreateResult tag */
 		$entityID = $createResponseNode->getElementsByTagName('CreateResult')->item(0)->textContent;
 		$entity->ID = $entityID;
 		$entity->reset();
 		return $entityID;
 	}
-	
+
 	/**
 	 * Generate a Create Request
 	 * @ignore
@@ -2075,10 +2075,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $createNode;
 	}
-	
+
 	/**
 	 * Check if an Entity Definition has been cached
-	 * 
+	 *
 	 * @param String $entityLogicalName Logical Name of the entity to check for in the Cache
 	 * @return boolean true if this Entity has been cached
 	 */
@@ -2090,10 +2090,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Cache the definition of an Entity
-	 * 
+	 *
 	 * @param String $entityLogicalName
 	 * @param SimpleXMLElement $entityData
 	 * @param Array $propertiesArray
@@ -2102,18 +2102,18 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	 * @param Array $optionSetsArray
 	 * @param String $entityDisplayName
 	 */
-	public function setCachedEntityDefinition($entityLogicalName, 
+	public function setCachedEntityDefinition($entityLogicalName,
 			SimpleXMLElement $entityData, Array $propertiesArray, Array $propertyValuesArray,
 			Array $mandatoriesArray, Array $optionSetsArray, $entityDisplayName) {
 		/* Store the details of the Entity Definition in the Cache */
 		$this->cachedEntityDefintions[$entityLogicalName] = Array(
-				$entityData, $propertiesArray, $propertyValuesArray, 
+				$entityData, $propertiesArray, $propertyValuesArray,
 				$mandatoriesArray, $optionSetsArray, $entityDisplayName);
 	}
-	
+
 	/**
 	 * Get the Definition of an Entity from the Cache
-	 * 
+	 *
 	 * @param String $entityLogicalName
 	 * @param SimpleXMLElement $entityData
 	 * @param Array $propertiesArray
@@ -2123,7 +2123,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	 * @param String $entityDisplayName
 	 * @return boolean true if the Cache was retrieved
 	 */
-	public function getCachedEntityDefinition($entityLogicalName, 
+	public function getCachedEntityDefinition($entityLogicalName,
 			&$entityData, Array &$propertiesArray, Array &$propertyValuesArray, Array &$mandatoriesArray,
 			Array &$optionSetsArray, &$entityDisplayName) {
 		/* Check that this Entity Definition has been Cached */
@@ -2152,7 +2152,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Send a Delete request to the Dynamics CRM 2011 server, and return ...
 	 *
@@ -2164,24 +2164,24 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Cannot Delete an Entity without an ID.');
 			return FALSE;
 		}
-		
+
 		/* Send the sequrity request and get a security token */
 		$securityToken = $this->getOrganizationSecurityToken();
 		/* Generate the XML for the Body of a Delete request */
 		$deleteNode = self::generateDeleteRequest($entity);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'Delete Request: '.PHP_EOL.$deleteNode->C14N().PHP_EOL.PHP_EOL;
-	
+
 		/* Turn this into a SOAP request, and send it */
 		$deleteRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationDeleteAction(), $securityToken, $deleteNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $deleteRequest);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'Delete Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
-	
+
 		/* Load the XML into a DOMDocument */
 		$soapResponseDOM = new DOMDocument();
 		$soapResponseDOM->loadXML($soapResponse);
-	
+
  		/* Find the DeleteResponse */
  		$deleteResponseNode = NULL;
  		foreach ($soapResponseDOM->getElementsByTagName('DeleteResponse') as $node) {
@@ -2196,7 +2196,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
  		/* Delete occurred successfully */
 		return TRUE;
 	}
-	
+
 	/**
 	 * Generate a Delete Request
 	 * @ignore
@@ -2210,7 +2210,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $deleteNode;
 	}
-	
+
 	/**
 	 * Send an Update request to the Dynamics CRM 2011 server, and return ...
 	 *
@@ -2222,24 +2222,24 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Cannot Update an Entity without an ID.');
 			return FALSE;
 		}
-		
+
 		/* Send the sequrity request and get a security token */
 		$securityToken = $this->getOrganizationSecurityToken();
 		/* Generate the XML for the Body of an Update request */
 		$updateNode = self::generateUpdateRequest($entity);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'Update Request: '.PHP_EOL.$updateNode->C14N().PHP_EOL.PHP_EOL;
-	
+
 		/* Turn this into a SOAP request, and send it */
 		$updateRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationUpdateAction(), $securityToken, $updateNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $updateRequest);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'Update Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
-	
+
 		/* Load the XML into a DOMDocument */
 		$soapResponseDOM = new DOMDocument();
 		$soapResponseDOM->loadXML($soapResponse);
-	
+
 		/* Find the UpdateResponse */
 		$updateResponseNode = NULL;
 		foreach ($soapResponseDOM->getElementsByTagName('UpdateResponse') as $node) {
@@ -2254,7 +2254,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Update occurred successfully */
 		return $updateResponseNode->C14N();
 	}
-	
+
 	/**
 	 * Generate an Update Request
 	 * @ignore
@@ -2267,10 +2267,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Return the DOMNode */
 		return $updateNode;
 	}
-	
-	/** 
+
+	/**
 	 * Send a SetStateRequest request to the Dynamics CRM 2011 server and return...
-	 * 
+	 *
 	 * @param DynamicsCRM2011_Entity $entity Entity that is to be updated
 	 * @param int $state StateCode to set
 	 * @param int $status StatusCode to set (or NULL to use StateCode)
@@ -2283,19 +2283,19 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$securityToken = $this->getOrganizationSecurityToken();
 		/* Generate the XML for the Body of a RetrieveRecordChangeHistory request */
 		$executeNode = self::generateSetStateRequest($entity, $state, $status);
-		
+
 		if (self::$debugMode) echo PHP_EOL.'SetState Request: '.PHP_EOL.$executeNode->C14N().PHP_EOL.PHP_EOL;
-		
+
 		/* Turn this into a SOAP request, and send it */
 		$setStateSoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $setStateSoapRequest);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'SetState Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
-	
+
 		/* Load the XML into a DOMDocument */
 		$soapResponseDOM = new DOMDocument();
 		$soapResponseDOM->loadXML($soapResponse);
-	
+
 		/* Find the ExecuteResponse */
 		$executeResponseNode = NULL;
 		foreach ($soapResponseDOM->getElementsByTagName('ExecuteResponse') as $node) {
@@ -2307,7 +2307,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Could not find ExecuteResponse node in XML returned from Server');
 			return FALSE;
 		}
-		
+
 		/* Find the ExecuteResult */
 		$executeResultNode = NULL;
 		foreach ($executeResponseNode->getElementsByTagName('ExecuteResult') as $node) {
@@ -2319,11 +2319,11 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 			throw new Exception('Could not find ExecuteResult node in XML returned from Server');
 			return FALSE;
 		}
-		
+
 		/* Update occurred successfully */
 		return true;
 	}
-	
+
 	/**
 	 * Generate a SetState Request
 	 * @ignore
@@ -2338,7 +2338,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$requestNode->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:c', 'http://schemas.microsoft.com/crm/2011/Contracts');
 		$parametersNode = $requestNode->appendChild($setStateRequestDOM->createElement('b:Parameters'));
 		$parametersNode->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:d', 'http://schemas.datacontract.org/2004/07/System.Collections.Generic');
-		
+
 		$keyValuePairNode1 = $parametersNode->appendChild($setStateRequestDOM->createElement('b:KeyValuePairOfstringanyType'));
 		$keyValuePairNode1->appendChild($setStateRequestDOM->createElement('d:key', 'EntityMoniker'));
 		$valueNode1 = $keyValuePairNode1->appendChild($setStateRequestDOM->createElement('d:value'));
@@ -2346,29 +2346,29 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$valueNode1->appendChild($setStateRequestDOM->createElement('b:Id', $entity->ID));
 		$valueNode1->appendChild($setStateRequestDOM->createElement('b:LogicalName', $entity->LogicalName));
 		$valueNode1->appendChild($setStateRequestDOM->createElement('b:Name'))->setAttribute('i:nil', 'true');
-		
+
 		$keyValuePairNode2 = $parametersNode->appendChild($setStateRequestDOM->createElement('b:KeyValuePairOfstringanyType'));
 		$keyValuePairNode2->appendChild($setStateRequestDOM->createElement('d:key', 'State'));
 		$valueNode2 = $keyValuePairNode2->appendChild($setStateRequestDOM->createElement('d:value'));
 		$valueNode2->setAttribute('i:type', 'b:OptionSetValue');
 		$valueNode2->appendChild($setStateRequestDOM->createElement('b:Value', $state));
-		
+
 		$keyValuePairNode3 = $parametersNode->appendChild($setStateRequestDOM->createElement('b:KeyValuePairOfstringanyType'));
 		$keyValuePairNode3->appendChild($setStateRequestDOM->createElement('d:key', 'Status'));
 		$valueNode3 = $keyValuePairNode3->appendChild($setStateRequestDOM->createElement('d:value'));
 		$valueNode3->setAttribute('i:type', 'b:OptionSetValue');
 		$valueNode3->appendChild($setStateRequestDOM->createElement('b:Value', $status));
-		
+
 		$requestNode->appendChild($setStateRequestDOM->createElement('b:RequestId'))->setAttribute('i:nil', 'true');
 		$requestNode->appendChild($setStateRequestDOM->createElement('b:RequestName', 'SetState'));
 		/* Return the DOMNode */
 		return $executeNode;
 	}
-	
+
 	/**
 	 * Get all the details of the Connector that would be needed to
 	 * bypass the normal login process next time...
-	 * Note that the Entity definition cache, the DOMs and the security 
+	 * Note that the Entity definition cache, the DOMs and the security
 	 * policies are excluded from the Cache.
 	 * @return Array
 	 */
@@ -2396,7 +2396,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				self::$connectorTimeout,
 				self::$maximumRecords,);
 	}
-	
+
 	/**
 	 * Restore the cached details
 	 * @param Array $loginCache
@@ -2425,10 +2425,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 				self::$connectorTimeout,
 				self::$maximumRecords) = $loginCache;
 	}
-	
+
 	/**
 	 * Search for a particular Entity using the entity type and name only
-	 * 
+	 *
 	 * @param String $entityLogicalName - Logical name of the entity to be found
 	 * @param String $searchField - Field to search in
 	 * @param String $searchValue - Text to search for
@@ -2447,7 +2447,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 END;
 		/* Launch the query */
 		$data = $this->retrieveMultiple($queryXML);
-		
+
 		/* Check how many results were found */
 		if ($data->Count == 1) {
 			/* Just one result - return it as is */
@@ -2460,23 +2460,23 @@ END;
 			return $data->Entities;
 		}
 	}
-	
+
 	/**
 	 * Set the CRM User that will be responsible for CRM updates from now on
-	 * 
+	 *
 	 * @param DynamicsCRM2011_SystemUser $_crmUser
 	 */
 	public function setUserOverride(DynamicsCRM2011_SystemUser $_crmUser) {
 		$this->callerId = $_crmUser;
 	}
-	
+
 	/**
 	 * Reset the user for Creates and Updates back to the default
 	 */
 	public function clearUserOverride() {
 		$this->callerId = NULL;
 	}
-	
+
 	/**
 	 * Send a CloseIncidentRequest request to the Dynamics CRM 2011 server and return...
 	 *
@@ -2490,19 +2490,19 @@ END;
 		$securityToken = $this->getOrganizationSecurityToken();
 		/* Generate the XML for the Body of a CloseIncidentRequest request */
 		$executeNode = self::generateCloseIncidentRequest($_resolution, $status);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'CloseIncident Request: '.PHP_EOL.$executeNode->C14N().PHP_EOL.PHP_EOL;
-	
+
 		/* Turn this into a SOAP request, and send it */
 		$setStateSoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
 		$soapResponse = self::getSoapResponse($this->organizationURI, $setStateSoapRequest);
-	
+
 		if (self::$debugMode) echo PHP_EOL.'CloseIncident Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
-	
+
 		/* Load the XML into a DOMDocument */
 		$soapResponseDOM = new DOMDocument();
 		$soapResponseDOM->loadXML($soapResponse);
-	
+
 		/* Find the ExecuteResponse */
 		$executeResponseNode = NULL;
 		foreach ($soapResponseDOM->getElementsByTagName('ExecuteResponse') as $node) {
@@ -2514,7 +2514,7 @@ END;
 			throw new Exception('Could not find ExecuteResponse node in XML returned from Server');
 			return FALSE;
 		}
-	
+
 		/* Find the ExecuteResult */
 		$executeResultNode = NULL;
 		foreach ($executeResponseNode->getElementsByTagName('ExecuteResult') as $node) {
@@ -2526,11 +2526,11 @@ END;
 			throw new Exception('Could not find ExecuteResult node in XML returned from Server');
 			return FALSE;
 		}
-	
+
 		/* Update occurred successfully */
 		return true;
 	}
-	
+
 	/**
 	 * Generate a CloseIncidentRequest
 	 * @ignore
@@ -2545,7 +2545,7 @@ END;
 		$requestNode->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:e', 'http://schemas.microsoft.com/crm/2011/Contracts');
 		$parametersNode = $requestNode->appendChild($closeIncidentRequestDOM->createElement('b:Parameters'));
 		$parametersNode->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:c', 'http://schemas.datacontract.org/2004/07/System.Collections.Generic');
-	
+
 		$keyValuePairNode1 = $parametersNode->appendChild($closeIncidentRequestDOM->createElement('b:KeyValuePairOfstringanyType'));
 		$keyValuePairNode1->appendChild($closeIncidentRequestDOM->createElement('c:key', 'IncidentResolution'));
 		$valueNode1 = $keyValuePairNode1->appendChild($closeIncidentRequestDOM->createElement('c:value'));
@@ -2556,13 +2556,13 @@ END;
 		$valueNode1->appendChild($closeIncidentRequestDOM->createElement('b:Id', self::EmptyGUID));
 		$valueNode1->appendChild($closeIncidentRequestDOM->createElement('b:LogicalName', $_resolution->LogicalName));
 		$valueNode1->appendChild($closeIncidentRequestDOM->createElement('b:RelatedEntities'));
-	
+
 		$keyValuePairNode2 = $parametersNode->appendChild($closeIncidentRequestDOM->createElement('b:KeyValuePairOfstringanyType'));
 		$keyValuePairNode2->appendChild($closeIncidentRequestDOM->createElement('c:key', 'Status'));
 		$valueNode2 = $keyValuePairNode2->appendChild($closeIncidentRequestDOM->createElement('c:value'));
 		$valueNode2->setAttribute('i:type', 'b:OptionSetValue');
 		$valueNode2->appendChild($closeIncidentRequestDOM->createElement('b:Value', $status));
-	
+
 		$requestNode->appendChild($closeIncidentRequestDOM->createElement('b:RequestId'))->setAttribute('i:nil', 'true');
 		$requestNode->appendChild($closeIncidentRequestDOM->createElement('b:RequestName', 'CloseIncident'));
 		/* Return the DOMNode */

--- a/DynamicsCRM2011_Connector.class.php
+++ b/DynamicsCRM2011_Connector.class.php
@@ -100,7 +100,6 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 	 * @param string $_username the Username to login with
 	 * @param string $_password the Password of the user
 	 * @param boolean $_debug display debug information when accessing the server - not recommended in Production!
-	 * @return DynamicsCRM2011Connector
 	 */
 	function __construct($_discoveryURI, $_organizationUniqueName = NULL, $_username = NULL, $_password = NULL, $_debug = FALSE) {
 		/* Enable or disable debug mode */

--- a/DynamicsCRM2011_Connector.class.php
+++ b/DynamicsCRM2011_Connector.class.php
@@ -252,7 +252,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 
 		/* Generate a Soap Request for the Retrieve Organization Request method of the Discovery Service */
 		$discoverySoapRequest = self::generateSoapRequest($this->discoveryURI, $discoveryServiceSoapAction, $securityToken, self::generateRetrieveOrganizationRequest());
-		$discovery_data = self::getSoapResponse($this->discoveryURI, $discoverySoapRequest);
+		$discovery_data = static::getSoapResponse($this->discoveryURI, $discoverySoapRequest);
 
 		/* Parse the returned data to determine the correct EndPoint for the OrganizationService for the selected Organization */
 		$organizationServiceURI = NULL;
@@ -999,7 +999,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		/* Generate the Security Token Request XML */
 		$loginSoapRequest = self::getLoginXML($securityServerURI, $loginEndpoint, $loginUsername, $loginPassword);
 		/* Send the Security Token request */
-		$security_xml = self::getSoapResponse($securityServerURI, $loginSoapRequest);
+		$security_xml = static::getSoapResponse($securityServerURI, $loginSoapRequest);
 		/* Convert the XML into a DOMDocument */
 		$securityDOM = new DOMDocument();
 		$securityDOM->loadXML($security_xml);
@@ -1789,7 +1789,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$executeNode = self::generateRetrieveMultipleRequest($queryXML, $pagingCookie, $limitCount);
 		/* Turn this into a SOAP request, and send it */
 		$retrieveMultipleSoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationRetrieveMultipleAction(), $securityToken, $executeNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveMultipleSoapRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $retrieveMultipleSoapRequest);
 
 		return $soapResponse;
 	}
@@ -1886,7 +1886,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$executeNode = self::generateRetrieveRecordChangeHistoryRequest($entityType, $entityId, $pagingCookie);
 		/* Turn this into a SOAP request, and send it */
 		$retrieveRecordChangeHistorySoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveRecordChangeHistorySoapRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $retrieveRecordChangeHistorySoapRequest);
 
 		return $soapResponse;
 	}
@@ -1947,7 +1947,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$executeNode = self::generateRetrieveRequest($entityType, $entityId, $fieldSet);
 		/* Turn this into a SOAP request, and send it */
 		$retrieveRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationRetrieveAction(), $securityToken, $executeNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $retrieveRequest);
 
 		return $soapResponse;
 	}
@@ -1992,7 +1992,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$executeNode = self::generateRetrieveEntityRequest($entityType, $entityId, $entityFilters, $showUnpublished);
 		/* Turn this into a SOAP request, and send it */
 		$retrieveEntityRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $retrieveEntityRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $retrieveEntityRequest);
 
 		return $soapResponse;
 	}
@@ -2035,7 +2035,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 
 		/* Turn this into a SOAP request, and send it */
 		$createRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationCreateAction(), $securityToken, $createNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $createRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $createRequest);
 
 		if (self::$debugMode) echo PHP_EOL.'Create Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
 
@@ -2173,7 +2173,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 
 		/* Turn this into a SOAP request, and send it */
 		$deleteRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationDeleteAction(), $securityToken, $deleteNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $deleteRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $deleteRequest);
 
 		if (self::$debugMode) echo PHP_EOL.'Delete Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
 
@@ -2231,7 +2231,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 
 		/* Turn this into a SOAP request, and send it */
 		$updateRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationUpdateAction(), $securityToken, $updateNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $updateRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $updateRequest);
 
 		if (self::$debugMode) echo PHP_EOL.'Update Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
 
@@ -2287,7 +2287,7 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 
 		/* Turn this into a SOAP request, and send it */
 		$setStateSoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $setStateSoapRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $setStateSoapRequest);
 
 		if (self::$debugMode) echo PHP_EOL.'SetState Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
 
@@ -2494,7 +2494,7 @@ END;
 
 		/* Turn this into a SOAP request, and send it */
 		$setStateSoapRequest = self::generateSoapRequest($this->organizationURI, $this->getOrganizationExecuteAction(), $securityToken, $executeNode, $this->callerId);
-		$soapResponse = self::getSoapResponse($this->organizationURI, $setStateSoapRequest);
+		$soapResponse = static::getSoapResponse($this->organizationURI, $setStateSoapRequest);
 
 		if (self::$debugMode) echo PHP_EOL.'CloseIncident Response: '.PHP_EOL.$soapResponse.PHP_EOL.PHP_EOL;
 

--- a/DynamicsCRM2011_Connector.class.php
+++ b/DynamicsCRM2011_Connector.class.php
@@ -1063,8 +1063,10 @@ class DynamicsCRM2011_Connector extends DynamicsCRM2011 {
 		$loginTimestamp->appendChild($loginSoapRequest->createElement('u:Expires', self::getExpiryTime().'Z'));
 		$loginUsernameToken = $loginSecurity->appendChild($loginSoapRequest->createElement('o:UsernameToken'));
 		$loginUsernameToken->setAttribute('u:Id', 'user');
+		$pass = $loginSoapRequest->createTextNode($loginPassword); // Force escaping of the password
+		$pass_str = $loginSoapRequest->saveXML($pass);
 		$loginUsernameToken->appendChild($loginSoapRequest->createElement('o:Username', $loginUsername));
-		$loginUsernameToken->appendChild($loginSoapRequest->createElement('o:Password', $loginPassword))->setAttribute('Type', 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText');
+		$loginUsernameToken->appendChild($loginSoapRequest->createElement('o:Password', $pass_str))->setAttribute('Type', 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText');
 		
 		$loginBody = $loginEnvelope->appendChild($loginSoapRequest->createElementNS('http://www.w3.org/2003/05/soap-envelope', 's:Body'));
 		$loginRST = $loginBody->appendChild($loginSoapRequest->createElementNS('http://docs.oasis-open.org/ws-sx/ws-trust/200512', 'trust:RequestSecurityToken'));

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -288,7 +288,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			return;
 		}
 		/* If this is a Lookup field, it MUST be set to an Entity of an appropriate type */
-		if ($this->properties[$property]['isLookup']) {
+		if ($this->properties[$property]['isLookup'] && !is_null($value)) {
 			/* Check the new value is an Entity */
 			if (!$value instanceOf self) {
 				$trace = debug_backtrace();

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -43,7 +43,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		}
 		/* Check we have a Logical Name for the Entity */
 		if ($this->entityLogicalName == NULL) {
-			throw new Execption('Cannot instantiate an abstract Entity - specify the Logical Name');
+			throw new Exception('Cannot instantiate an abstract Entity - specify the Logical Name');
 		}
 		/* Set the Domain that this Entity is associated with */
 		$this->setEntityDomain($conn);
@@ -584,6 +584,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 						case 'int':
 						case 'decimal':
 						case 'double':
+						case 'Money':
 						case 'guid':
 							/* No special handling for these types */
 							break;
@@ -742,6 +743,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 					break;
 				case 'decimal':
 				case 'double':
+				case 'Money':
 					/* Decimal - Cast the String to a Float */
 					$storedValue = (float)$attributeValue;
 					break;
@@ -984,6 +986,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 				case 'Status':
 				case 'Decimal':
 				case 'Double':
+				case 'Money':
 				case 'Uniqueidentifier':
 				case 'Memo':
 				case 'String':

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -612,7 +612,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 					/* Now create the XML Node for the Value */
 					$valueNode = $propertyNode->appendChild($entityDOM->createElement('c:value'));
 
-					if ($xmlValue !== null)
+					if ($xmlValue !== null || $xmlType == 'OptionSetValue')
 					{
 						/* Set the Type of the Value */
 						$valueNode->setAttribute('i:type', 'd:'.$xmlType);

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -549,7 +549,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 				/* Set the Property Name */
 				$propertyNode->appendChild($entityDOM->createElement('c:key', $property));
 				/* Check the Type of the Value */
-				if ($propertyDetails['isLookup']) {
+				if ($propertyDetails['isLookup'] && !is_null($this->propertyValues[$property]['Value'])) {
 					/* Special handling for Lookups - use an EntityReference, not the AttributeType */
 					$valueNode = $propertyNode->appendChild($entityDOM->createElement('c:value'));
 					$valueNode->setAttribute('i:type', 'b:EntityReference');

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -43,7 +43,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 
 	/**
 	 *
-	 * @param DynamicsCRM2011Connector $conn Connection to the Dynamics CRM server - should be active already.
+	 * @param DynamicsCRM2011_Connector $conn Connection to the Dynamics CRM server - should be active already.
 	 * @param String $_logicalName Allows constructing arbritrary Entities by setting the EntityLogicalName directly
 	 */
 	function __construct(DynamicsCRM2011_Connector $conn, $_logicalName = NULL) {
@@ -210,7 +210,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 	/**
 	 *
 	 * @param String $property to be fetched
-	 * @return value of the property, if it exists & is readable
+	 * @return mixed Value of the property, if it exists & is readable
 	 */
 	public function __get($property) {
 		/* Handle special fields */

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -352,7 +352,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			}
 
 			/* Check we found a valid OptionSetValue */
-			if ($optionSetValue != NULL) {
+			if ($optionSetValue != NULL || is_null($value)) {
 				/* Set the value to be retained */
 				$value = $optionSetValue;
 				/* Clear any AttributeOf related to this field */
@@ -585,10 +585,14 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 						case 'state':
 						case 'status':
 							/* OptionSetValue - Just get the numerical value, but as an XML structure */
-							$xmlType = 'OptionSetValue';
-							$xmlTypeNS = 'http://schemas.microsoft.com/xrm/2011/Contracts';
 							$xmlValue = NULL;
-							$xmlValueChild = $entityDOM->createElement('b:Value', $this->propertyValues[$property]['Value']->Value);
+
+							if (!is_null($this->propertyValues[$property]['Value']))
+							{
+								$xmlType = 'OptionSetValue';
+								$xmlTypeNS = 'http://schemas.microsoft.com/xrm/2011/Contracts';
+								$xmlValueChild = $entityDOM->createElement('b:Value', $this->propertyValues[$property]['Value']->Value);
+							}
 							break;
 						case 'boolean':
 							/* Boolean - Just get the numerical value */

--- a/DynamicsCRM2011_Entity.class.php
+++ b/DynamicsCRM2011_Entity.class.php
@@ -2,6 +2,22 @@
 
 require_once 'DynamicsCRM2011.php';
 
+/**
+ *
+ * @property string $ID
+ * @property string $LOGICALNAME
+ * @property string $DISPLAYNAME
+ *
+ * @property integer $createdon
+ * @property integer $createdby
+ * @property integer $modifiedon
+ * @property integer $modifiedby
+ *
+ * @property DynamicsCRM2011_OptionSetValue $statecode
+ * @property DynamicsCRM2011_OptionSetValue $statuscode
+ *
+ * @property DynamicsCRM2011_Entity $ownerid
+ */
 class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 	/**
 	 * Overridden in each child class
@@ -24,9 +40,9 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 	private $entityID;
 	/* The Domain/URL of the Dynamics CRM 2011 Server where this is stored */
 	private $entityDomain = NULL;
-	
+
 	/**
-	 * 
+	 *
 	 * @param DynamicsCRM2011Connector $conn Connection to the Dynamics CRM server - should be active already.
 	 * @param String $_logicalName Allows constructing arbritrary Entities by setting the EntityLogicalName directly
 	 */
@@ -50,16 +66,16 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Check if the Definition of this Entity is Cached on the Connector */
 		if ($conn->isEntityDefinitionCached($this->entityLogicalName)) {
 			/* Use the Cached values */
-			$isDefined = $conn->getCachedEntityDefinition($this->entityLogicalName, 
+			$isDefined = $conn->getCachedEntityDefinition($this->entityLogicalName,
 					$this->entityData, $this->properties, $this->propertyValues, $this->mandatories,
 					$this->optionSets, $this->entityDisplayName);
-			if ($isDefined) return;	
+			if ($isDefined) return;
 		}
-		
+
 		/* At this point, we assume Entity is not Cached */
 		/* So, get the full details of what an Incident is on this server */
 		$this->entityData = $conn->retrieveEntity($this->entityLogicalName);
-		
+
 		/* Next, we analyse this data and determine what Properties this Entity has */
 		foreach ($this->entityData->children('http://schemas.microsoft.com/xrm/2011/Metadata')->Attributes[0]->AttributeMetadata as $attribute) {
 			/* Determine the Type of the Attribute */
@@ -87,14 +103,14 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 				$optionSetType = (String)$attribute->OptionSet->OptionSetType;
 				/* Array to store the Options for this OptionSet */
 				$optionSetValues = Array();
-				
+
 				/* Debug logging - Identify the OptionSet */
 				if (self::$debugMode) {
 					echo 'Attribute '.(String)$attribute->SchemaName.' is an OptionSet'.PHP_EOL;
 					echo "\tName:\t".$optionSetName.($optionSetGlobal ? ' (Global)' : '').PHP_EOL;
 					echo "\tType:\t".$optionSetType.PHP_EOL;
 				}
-				
+
 				/* Handle the different types of OptionSet */
 				switch ($optionSetType) {
 					case 'Boolean':
@@ -130,14 +146,14 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 						trigger_error('No OptionSet handling implemented for Type '.$optionSetType.' used by field '.(String)$attribute->SchemaName.' in Entity '.$this->entityLogicalName,
 								E_USER_WARNING);
 				}
-				
+
 				/* DebugLogging - Identify the OptionSet Values */
 				if (self::$debugMode) {
 					foreach ($optionSetValues as $value => $label) {
 						echo "\t\tOption ".$value.' => '.$label.PHP_EOL;
 					}
 				}
-				
+
 				/* Save this OptionSet in the Design */
 				if (array_key_exists($optionSetName, $this->optionSets)) {
 					/* If this isn't a Global OptionSet, warn of the name clash */
@@ -183,16 +199,16 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 				$this->mandatories[strtolower((String)$attribute->LogicalName)] = $requiredLevel;
 			}
 		}
-		
+
 		/* Ensure that this Entity Definition is Cached for next time */
-		$conn->setCachedEntityDefinition($this->entityLogicalName, 
+		$conn->setCachedEntityDefinition($this->entityLogicalName,
 				$this->entityData, $this->properties, $this->propertyValues, $this->mandatories,
 				$this->optionSets, $this->entityDisplayName);
 		return;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param String $property to be fetched
 	 * @return value of the property, if it exists & is readable
 	 */
@@ -230,14 +246,14 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		}
 		/* Property doesn't exist - standard error */
 		$trace = debug_backtrace();
-		trigger_error('Undefined property via __get(): ' . $property 
+		trigger_error('Undefined property via __get(): ' . $property
 				. ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
 				E_USER_NOTICE);
 		return NULL;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param String $property to be changed
 	 * @param mixed $value new value for the property
 	 */
@@ -260,7 +276,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Property doesn't exist - standard error */
 		if (!array_key_exists($property, $this->properties)) {
 			$trace = debug_backtrace();
-			trigger_error('Undefined property via __set() - ' . $this->entityLogicalName . ' does not support property: ' . $property 
+			trigger_error('Undefined property via __set() - ' . $this->entityLogicalName . ' does not support property: ' . $property
 					. ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
 					E_USER_NOTICE);
 			return;
@@ -302,7 +318,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			$optionSetName = $this->properties[$property]['OptionSet'];
 			/* Container for the final value */
 			$optionSetValue = NULL;
-			
+
 			/* Handle passing a Boolean value */
 			if ($value === TRUE) $value = 1;
 			elseif ($value === FALSE) $value = 0;
@@ -334,7 +350,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 					$optionSetValue = $value;
 				}
 			}
-			
+
 			/* Check we found a valid OptionSetValue */
 			if ($optionSetValue != NULL) {
 				/* Set the value to be retained */
@@ -355,7 +371,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Mark the property as changed */
 		$this->propertyValues[$property]['Changed'] = true;
 	}
-	
+
 	/**
 	 * Check if a property exists on this entity.  Called by isset().
 	 * Note that this implementation does not check if the property is actually a non-null value.
@@ -393,7 +409,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Utility function to clear all "AttributeOf" fields relating to the base field
 	 * @param String $baseProperty
@@ -408,7 +424,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			}
 		}
 	}
-	
+
 	/**
 	 * @return String description of the Entity including Type, DisplayName and ID
 	 */
@@ -424,7 +440,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* EntityType: Display Name <GUID> */
 		return $this->entityLogicalName.$displayName.'<'.$this->getID().'>';
 	}
-	
+
 	/**
 	 * Reset all changed values to unchanged
 	 */
@@ -434,7 +450,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			$property['Changed'] = false;
 		}
 	}
-	
+
 	/**
 	 * Check if a property has been changed since creation of the Entity
 	 * @param String $property
@@ -453,7 +469,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		}
 		return $this->propertyValues[$property]['Changed'];
 	}
-	
+
 	/**
 	 * Private utility function to get the ID field; enforces NULL --> EmptyGUID
 	 * @ignore
@@ -462,7 +478,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		if ($this->entityID == NULL) return self::EmptyGUID;
 		else return $this->entityID;
 	}
-	
+
 	/**
 	 * Private utility function to set the ID field; enforces "Set Once" logic
 	 * @param String $value
@@ -475,7 +491,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		}
 		$this->entityID = $value;
 	}
-	
+
 	/**
 	 * Utility function to check all mandatory fields are filled
 	 * @param Array $details populated with any failures found
@@ -510,11 +526,11 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Return the result */
 		return $allMandatoriesFilled;
 	}
-	
+
 	/**
-	 * Create a DOMNode that represents this Entity, and can be used in a Create or Update 
+	 * Create a DOMNode that represents this Entity, and can be used in a Create or Update
 	 * request to the CRM server
-	 * 
+	 *
 	 * @param boolean $allFields indicates if we should include all fields, or only changed fields
 	 */
 	public function getEntityDOM($allFields = false) {
@@ -558,7 +574,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 							break;
 						case 'datetime':
 							/* Date/Time - Stored in the Entity as a PHP Date, needs to be XML format. Type is also mixed-case */
-							$xmlValue = gmdate("Y-m-d\TH:i:s\Z", $xmlValue);
+							if ($xmlValue !== null) $xmlValue = gmdate("Y-m-d\TH:i:s\Z", $xmlValue);
 							$xmlType = 'dateTime';
 							break;
 						case 'uniqueidentifier':
@@ -576,7 +592,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 							break;
 						case 'boolean':
 							/* Boolean - Just get the numerical value */
-							if (is_object($this->propertyValues[$property]['Value'])) 
+							if (is_object($this->propertyValues[$property]['Value']))
 								$xmlValue = $this->propertyValues[$property]['Value']->Value;
 							else $xmlValue = $this->propertyValues[$property]['Value'];
 							break;
@@ -595,11 +611,20 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 					}
 					/* Now create the XML Node for the Value */
 					$valueNode = $propertyNode->appendChild($entityDOM->createElement('c:value'));
-					/* Set the Type of the Value */
-					$valueNode->setAttribute('i:type', 'd:'.$xmlType);
-					$valueNode->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:d', $xmlTypeNS);
-					/* If there is a child node needed, append it */
-					if ($xmlValueChild !== NULL) $valueNode->appendChild($xmlValueChild);
+
+					if ($xmlValue !== null)
+					{
+						/* Set the Type of the Value */
+						$valueNode->setAttribute('i:type', 'd:'.$xmlType);
+						$valueNode->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:d', $xmlTypeNS);
+						/* If there is a child node needed, append it */
+						if ($xmlValueChild !== NULL) $valueNode->appendChild($xmlValueChild);
+					}
+					else
+					{
+						$valueNode->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'i:nil', 'true');
+					}
+
 					/* If there is a value, set it */
 					if ($xmlValue !== NULL) $valueNode->appendChild(new DOMText($xmlValue));
 				}
@@ -620,10 +645,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Return the root node for the Entity */
 		return $entityNode;
 	}
-	
+
 	/**
 	 * Generate an Entity based on a particular Logical Name - will try to be as Strongly Typed as possible
-	 * 
+	 *
 	 * @param DynamicsCRM2011_Connector $conn
 	 * @param String $entityLogicalName
 	 * @return DynamicsCRM2011_Entity of the specified type, or a generic Entity if no Class exists
@@ -638,10 +663,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Create a new instance of the Class */
 		return new $entityClassName($conn, $entityLogicalName);
 	}
-	
+
 	/**
 	 * Generate an Entity from the DOM object that describes its properties
-	 * 
+	 *
 	 * @param DynamicsCRM2011_Connector $conn
 	 * @param String $entityLogicalName
 	 * @param DOMElement $domNode
@@ -650,14 +675,14 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 	public static function fromDOM(DynamicsCRM2011_Connector $conn, $entityLogicalName, DOMElement $domNode) {
 		/* Create a new instance of the appropriate Class */
 		$entity = self::fromLogicalName($conn, $entityLogicalName);
-		
+
 		/* Store values from the main RetrieveResult node */
 		$relatedEntitiesNode = NULL;
 		$attributesNode = NULL;
 		$formattedValuesNode = NULL;
 		$retrievedEntityName = NULL;
 		$entityState = NULL;
-		
+
  		/* Loop through the nodes directly beneath the RetrieveResult node */
  		foreach ($domNode->childNodes as $childNode) {
 			switch ($childNode->localName) {
@@ -682,26 +707,26 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		 			break;
 			}
  		}
- 		
+
  		/* Verify that the Retrieved Entity Name matches the expected one */
  		if ($retrievedEntityName != $entityLogicalName) {
  			trigger_error('Expected to get a '.$entityLogicalName.' but actually received a '.$retrievedEntityName.' from the server!',
  					E_USER_WARNING);
  		}
-		
+
  		/* Log the Entity State - Never seen this used! */
  		if (self::$debugMode) echo 'Entity <'.$entity->ID.'> has EntityState: '.$entityState.PHP_EOL;
- 		
+
  		/* Parse the Attributes & FormattedValues to set the properties of the Entity */
  		$entity->setAttributesFromDOM($conn, $attributesNode, $formattedValuesNode);
- 		
+
 		/* Before returning the Entity, reset it so all fields are marked unchanged */
 		$entity->reset();
 		return $entity;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param DynamicsCRM2011_Connector $conn
 	 * @param DOMElement $attributesNode
 	 * @param DOMElement $formattedValuesNode
@@ -714,7 +739,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		$keyValueNodes = $formattedValuesNode->getElementsByTagName('KeyValuePairOfstringstring');
 		/* Add the Formatted Values in the Key/Value Pairs of String/String to the Array */
 		self::addFormattedValues($formattedValues, $keyValueNodes);
-		
+
 		/* Identify the Attributes */
 		$keyValueNodes = $attributesNode->getElementsByTagName('KeyValuePairOfstringanyType');
 		foreach ($keyValueNodes as $keyValueNode) {
@@ -878,7 +903,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 							$aliasAttributeValueNode->appendChild($aliasDoc->importNode($child, true));
 						}
 						/* Ensure we have the Type attribute, with Namespace */
-						$aliasAttributeValueNode->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'i:type', 
+						$aliasAttributeValueNode->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'i:type',
 								$keyValueNode->getElementsByTagName('value')->item(0)->getElementsByTagName('Value')->item(0)->getAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'type'));
 						/* Re-create the DOMElement for this Attribute's FormattedValue */
 						$aliasFormattedValuesNode = $aliasDoc->appendChild($aliasDoc->createElementNS('http://schemas.microsoft.com/xrm/2011/Contracts', 'b:FormattedValues'));
@@ -918,10 +943,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			}
 		}
 	}
-	
+
 	/**
 	 * Print a human-readable summary of the Entity with all details and fields
-	 * 
+	 *
 	 * @param boolean $recursive if TRUE, prints full details for all sub-entities as well
 	 * @param int $tabLevel the started level of indentation used (tabs)
 	 * @param boolean $printEmpty if TRUE, prints the details of NULL fields
@@ -943,7 +968,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			} else {
 				$propertyDetails = $this->localProperties[$property];
 			}
-			
+
 			/* In Recursive Mode, don't display "AttributeOf" fields */
 			if ($recursive && $propertyDetails['AttributeOf'] != NULL) continue;
 			/* Don't print NULL fields if printEmpty is FALSE */
@@ -1005,10 +1030,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			}
 		}
 	}
-	
+
 	/**
 	 * Get a URL that can be used to directly open the Entity Details on the CRM
-	 * 
+	 *
 	 * @param boolean $absolute If true, include the full domain; otherwise, just return a relative URL.
 	 * @return NULL|string the URL for the Entity on the CRM
 	 */
@@ -1024,7 +1049,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 			return $entityURL;
 		}
 	}
-	
+
 	/**
 	 * Update the Domain Name that this Entity will use when constructing an absolute URL
 	 * @param DynamicsCRM2011_Connector $conn Connection to the Server currently used
@@ -1042,10 +1067,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Update the Entity */
 		$this->entityDomain = $domainURL;
 	}
-	
+
 	/**
 	 * Get the possible values for a particular OptionSet property
-	 * 
+	 *
 	 * @param String $property to list values for
 	 * @return Array list of the available options for this Property
 	 */
@@ -1059,10 +1084,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Return the available options for this property */
 		return $this->optionSets[$optionSetName];
 	}
-	
+
 	/**
 	 * Get the label for a field
-	 * 
+	 *
 	 * @param String $property
 	 * @return string
 	 */
@@ -1080,10 +1105,10 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		/* Property doesn't exist, return empty string */
 		return '';
 	}
-	
-	/** 
-	 * Reset the fields so this Entity can be used in a Create 
-	 * 
+
+	/**
+	 * Reset the fields so this Entity can be used in a Create
+	 *
 	 * @param DynamicsCRM2011_Connector $conn - the connection that will be used to recreate this entity
 	 */
 	public function resetForCreate(DynamicsCRM2011_Connector $conn = NULL) {
@@ -1091,7 +1116,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 		$this->entityID = NULL;
 		/* If we're moving Server, reset the Domain */
 		if ($conn != NULL)  $this->setEntityDomain($conn);
-		
+
 		/* Loop through all the properties */
 		foreach ($this->properties as $property => $propertyDetails) {
 			/* Check if the property can be set on Create */
@@ -1118,7 +1143,7 @@ class DynamicsCRM2011_Entity extends DynamicsCRM2011 {
 					trigger_error('No new value for '.$property.' when moving to the new CRM instance: clearing!', E_USER_WARNING);
 					$this->propertyValues[$property]['Value'] = NULL;
 					$this->propertyValues[$property]['Changed'] = false;
-				}			
+				}
 			} else {
 				/* Otherwise, leave as is and mark it changed if not NULL */
 				$this->propertyValues[$property]['Changed'] = ($this->propertyValues[$property]['Value'] != NULL);

--- a/DynamicsCRM2011_OptionSetValue.class.php
+++ b/DynamicsCRM2011_OptionSetValue.class.php
@@ -2,15 +2,20 @@
 
 require_once 'DynamicsCRM2011.php';
 
+/**
+ *
+ * @property integer $value
+ * @property string $label
+ */
 class DynamicsCRM2011_OptionSetValue extends DynamicsCRM2011 {
 	/* Value */
 	protected $value = NULL;
 	/* Label */
 	protected $label = NULL;
-	
+
 	/**
 	 * Create a new OptionSetValue
-	 * 
+	 *
 	 * @param int $_value the Value of the Option
 	 * @param String $_label the Label of the Option
 	 */
@@ -19,10 +24,10 @@ class DynamicsCRM2011_OptionSetValue extends DynamicsCRM2011 {
 		$this->value = $_value;
 		$this->label = $_label;
 	}
-	
+
 	/**
-	 * Handle the retrieval of properties 
-	 * 
+	 * Handle the retrieval of properties
+	 *
 	 * @param String $name
 	 */
 	public function __get($property) {
@@ -34,7 +39,7 @@ class DynamicsCRM2011_OptionSetValue extends DynamicsCRM2011 {
 			case 'label':
 				return $this->label;
 		}
-		
+
 		/* Property doesn't exist - standard error */
 		$trace = debug_backtrace();
 		trigger_error('Undefined property via __get(): ' . $property
@@ -42,7 +47,7 @@ class DynamicsCRM2011_OptionSetValue extends DynamicsCRM2011 {
 				E_USER_NOTICE);
 		return NULL;
 	}
-	
+
 	/**
 	 * @return String description of the OptionSetValue including Value and Label
 	 */


### PR DESCRIPTION
I have made a few tweaks:
1. Passwords were not being XML escaped, causing a failure if a password contained an XML control character such as &
2. Fixed a class name typo when throwing an exception
3. Added the Money attribute type to be equivalent to a double.
